### PR TITLE
MOBILE-2906 Add course option type that appears in menu

### DIFF
--- a/src/core/course/pages/section/section.html
+++ b/src/core/course/pages/section/section.html
@@ -15,6 +15,7 @@
                         <core-context-menu-item *ngIf="displayEnableDownload" [priority]="2000" [content]="'core.settings.showdownloadoptions' | translate" (action)="toggleDownload()" [iconAction]="downloadEnabledIcon"></core-context-menu-item>
                         <core-context-menu-item [hidden]="!downloadCourseEnabled" [priority]="1900" [content]="prefetchCourseData.title | translate" (action)="prefetchCourse()" [iconAction]="prefetchCourseData.prefetchCourseIcon" [closeOnClick]="false"></core-context-menu-item>
                         <core-context-menu-item [priority]="1800" [content]="'core.course.coursesummary' | translate" (action)="openCourseSummary()" iconAction="fa-graduation-cap"></core-context-menu-item>
+                        <core-context-menu-item *ngFor="let item of courseMenuHandlers" [priority]="item.priority" (action)="openMenuItem(item)" [content]="item.data.title | translate" [iconAction]="item.data.icon" [class]="item.data.class"></core-context-menu-item>
                     </core-context-menu>
                 </core-navbar-buttons>
                 <ion-content #courseSectionContent>

--- a/src/core/course/pages/section/section.ts
+++ b/src/core/course/pages/section/section.ts
@@ -24,7 +24,8 @@ import { CoreCourseProvider } from '../../providers/course';
 import { CoreCourseHelperProvider } from '../../providers/helper';
 import { CoreCourseFormatDelegate } from '../../providers/format-delegate';
 import { CoreCourseModulePrefetchDelegate } from '../../providers/module-prefetch-delegate';
-import { CoreCourseOptionsDelegate, CoreCourseOptionsHandlerToDisplay } from '../../providers/options-delegate';
+import { CoreCourseOptionsDelegate, CoreCourseOptionsHandlerToDisplay,
+    CoreCourseOptionsMenuHandlerToDisplay } from '../../providers/options-delegate';
 import { CoreCourseSyncProvider } from '../../providers/sync';
 import { CoreCourseFormatComponent } from '../../components/format/format';
 import { CoreCoursesProvider } from '@core/courses/providers/courses';
@@ -49,6 +50,7 @@ export class CoreCourseSectionPage implements OnDestroy {
     sectionId: number;
     sectionNumber: number;
     courseHandlers: CoreCourseOptionsHandlerToDisplay[];
+    courseMenuHandlers: CoreCourseOptionsMenuHandlerToDisplay[] = [];
     dataLoaded: boolean;
     downloadEnabled: boolean;
     downloadEnabledIcon = 'square-outline'; // Disabled by default.
@@ -301,6 +303,11 @@ export class CoreCourseSectionPage implements OnDestroy {
                 }
             }));
 
+            // Load the course menu handlers.
+            promises.push(this.courseOptionsDelegate.getMenuHandlersToDisplay(this.injector, this.course).then((handlers) => {
+                this.courseMenuHandlers = handlers;
+            }));
+
             // Load the course format options when course completion is enabled to show completion progress on sections.
             if (this.course.enablecompletion && this.coursesProvider.isGetCoursesByFieldAvailable()) {
                 promises.push(this.coursesProvider.getCoursesByField('id', this.course.id).catch(() => {
@@ -417,7 +424,8 @@ export class CoreCourseSectionPage implements OnDestroy {
      * Prefetch the whole course.
      */
     prefetchCourse(): void {
-        this.courseHelper.confirmAndPrefetchCourse(this.prefetchCourseData, this.course, this.sections, this.courseHandlers)
+        this.courseHelper.confirmAndPrefetchCourse(this.prefetchCourseData, this.course, this.sections,
+                this.courseHandlers, this.courseMenuHandlers)
                 .then(() => {
             if (this.downloadEnabled) {
                 // Recalculate the status.
@@ -457,6 +465,16 @@ export class CoreCourseSectionPage implements OnDestroy {
      */
     openCourseSummary(): void {
         this.navCtrl.push('CoreCoursesCoursePreviewPage', {course: this.course, avoidOpenCourse: true});
+    }
+
+    /**
+     * Opens a menu item registered to the delegate.
+     *
+     * @param {CoreCourseMenuHandlerToDisplay} item Item to open
+     */
+    openMenuItem(item: CoreCourseOptionsMenuHandlerToDisplay): void {
+        const params = Object.assign({ course: this.course}, item.data.pageParams);
+        this.navCtrl.push(item.data.page, params);
     }
 
     /**


### PR DESCRIPTION
This allows addons to add items to the course menu. The items work
in the same way as other course options, except that instead of
appearing as a tab, they appear as an option in the course menu.